### PR TITLE
Disable rewards intro functionality

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,6 +59,7 @@ module.exports = {
     STAKING_SCRAP:
       process.env.STAKING_SCRAP ||
       'https://strapi-production-5f75.up.railway.app',
+    REWARDS_INTRO_ACTIVE: process.env.REWARDS_INTRO_ACTIVE,
     STAKING_SCRAP_TOKEN:
       process.env.STAKING_SCRAP_TOKEN ||
       '64884814288cec3482534e508918677352f7199bc03cb4a80b0ee18a10fc479e237dabd77cd514722eccd37523dc1cc5286f67995726df6cd038cffcd5e202581f90d56bebf08515005366a1eacaafeefa4471e04128279b796c84a9b84b0603cd401169d754300ee12e9fc1cb5ed43d02331bba02c35ecc1520debd8e49e662',

--- a/src/components/Intro/index.tsx
+++ b/src/components/Intro/index.tsx
@@ -20,7 +20,7 @@ const initialState = process.browser && localStorage.getItem(DEFAULTINTRONAME);
 
 export function Intro({ children }: { children: ReactNode }) {
   const { hasRewards } = useRewards();
-
+  const isIntroActive = process.env.REWARDS_INTRO_ACTIVE === 'true';
   const steps: StepType[] = useMemo(
     () => [
       {
@@ -110,7 +110,7 @@ export function Intro({ children }: { children: ReactNode }) {
   return (
     <TourProvider
       steps={steps}
-      defaultOpen={!initialState}
+      defaultOpen={isIntroActive ? !initialState : false}
       ContentComponent={ContentComponent}
     >
       {children}

--- a/src/components/Rewards/Hero/index.tsx
+++ b/src/components/Rewards/Hero/index.tsx
@@ -27,6 +27,8 @@ export const Hero = () => {
       )}`,
     [account],
   );
+  const isIntroActive = process.env.REWARDS_INTRO_ACTIVE === 'true';
+
   const { setIsOpen, setCurrentStep } = useTour();
 
   return (
@@ -202,15 +204,17 @@ export const Hero = () => {
           </S.Arrow>
         </S.Container>
       </S.Box>
-      <S.IntroButton
-        type="button"
-        onClick={() => {
-          setIsOpen(true);
-          setCurrentStep(0);
-        }}
-      >
-        Tutorial
-      </S.IntroButton>
+      {isIntroActive && (
+        <S.IntroButton
+          type="button"
+          onClick={() => {
+            setIsOpen(true);
+            setCurrentStep(0);
+          }}
+        >
+          Tutorial
+        </S.IntroButton>
+      )}
     </S.Wrapper>
   );
 };


### PR DESCRIPTION
This pull request introduces a new feature that allows the disabling or enabling of the intro interaction in the rewards page through an environment variable. The intro section provides an initial overview and instructions for users, but it can now be easily controlled based on the environment configuration.

To achieve this, the following changes have been made:

Added a new environment variable, REWARDS_INTRO_ACTIVE, which can be set to true or false to disable or enable the intro section, respectively.